### PR TITLE
Implement multi-variable branching for 0/1-Knapsack

### DIFF
--- a/.github/workflows/tests-knapsack-mb.yml
+++ b/.github/workflows/tests-knapsack-mb.yml
@@ -1,0 +1,53 @@
+name: Knapsack tests with multi-variable branching
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  tests-knapsack:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        test_runs:
+          - ./tests_knapsack_dantzig.sh MB=2
+          - ./tests_knapsack_dantzig.sh MB=3
+          - ./tests_knapsack_dantzig.sh MB=4
+          - ./tests_knapsack_dantzig.sh MB=5
+          - ./tests_knapsack_martello.sh MB=2
+          - ./tests_knapsack_martello.sh MB=3
+          - ./tests_knapsack_martello.sh MB=4
+          - ./tests_knapsack_martello.sh MB=5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Load CI environment
+        run: cat .github/workflows/ci.env >> $GITHUB_ENV
+
+      - name: Restore Chapel cache
+        id: cache-chapel
+        uses: actions/cache@v5
+        with:
+          path: ~/${{ env.CHAPEL_DIR }}
+          key: ${{ runner.os }}-${{ env.CHAPEL_CACHE_KEY }}
+
+      - name: Build Chapel (if needed)
+        if: steps.cache-chapel.outputs.cache-hit != 'true'
+        working-directory: chpl_config
+        run: source laptop_multicore.sh
+
+      - name: Compile Knapsack
+        working-directory: chpl_config
+        run: |
+          source laptop_multicore.sh --no-build
+          make main_knapsack.out
+
+      - name: Run tests
+        working-directory: tests
+        run: ${{ matrix.test_runs }}

--- a/.github/workflows/tests-knapsack-mb.yml
+++ b/.github/workflows/tests-knapsack-mb.yml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       matrix:
         test_runs:
-          - ./tests_knapsack_dantzig.sh MB=2
-          - ./tests_knapsack_dantzig.sh MB=3
-          - ./tests_knapsack_dantzig.sh MB=4
-          - ./tests_knapsack_dantzig.sh MB=5
-          - ./tests_knapsack_martello.sh MB=2
-          - ./tests_knapsack_martello.sh MB=3
-          - ./tests_knapsack_martello.sh MB=4
-          - ./tests_knapsack_martello.sh MB=5
+          - ./tests_knapsack_dantzig.sh 2
+          - ./tests_knapsack_dantzig.sh 3
+          - ./tests_knapsack_dantzig.sh 4
+          - ./tests_knapsack_dantzig.sh 5
+          - ./tests_knapsack_martello.sh 2
+          - ./tests_knapsack_martello.sh 3
+          - ./tests_knapsack_martello.sh 4
+          - ./tests_knapsack_martello.sh 5
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tests-knapsack.yml
+++ b/.github/workflows/tests-knapsack.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        test_script:
+        test_scripts:
           - tests_knapsack_dantzig.sh
           - tests_knapsack_martello.sh
 
@@ -44,4 +44,4 @@ jobs:
 
       - name: Run tests
         working-directory: tests
-        run: ./${{ matrix.test_script }}
+        run: ./${{ matrix.test_scripts }}

--- a/.github/workflows/tests-pfsp.yml
+++ b/.github/workflows/tests-pfsp.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        test_script:
+        test_scripts:
           - tests_pfsp_lb1.sh
           - tests_pfsp_lb1_d.sh
           - tests_pfsp_lb2.sh
@@ -45,4 +45,4 @@ jobs:
 
       - name: Run tests
         working-directory: tests
-        run: ./${{ matrix.test_script }}
+        run: ./${{ matrix.test_scripts }}

--- a/.github/workflows/tests-qap.yml
+++ b/.github/workflows/tests-qap.yml
@@ -13,9 +13,10 @@ jobs:
 
     strategy:
       matrix:
-        test_script:
+        test_scripts:
           - tests_qap_glb.sh
-          - tests_qap_hhb.sh
+          - tests_qap_rlt1.sh
+          - tests_qap_rlt2.sh
 
     steps:
       - name: Checkout repository
@@ -44,4 +45,4 @@ jobs:
 
       - name: Run tests
         working-directory: tests
-        run: ./${{ matrix.test_script }}
+        run: ./${{ matrix.test_scripts }}

--- a/.github/workflows/tests-qap.yml
+++ b/.github/workflows/tests-qap.yml
@@ -15,8 +15,7 @@ jobs:
       matrix:
         test_scripts:
           - tests_qap_glb.sh
-          - tests_qap_rlt1.sh
-          - tests_qap_rlt2.sh
+          - tests_qap_hhb.sh
 
     steps:
       - name: Checkout repository

--- a/benchmarks/Knapsack/Problem_Knapsack.chpl
+++ b/benchmarks/Knapsack/Problem_Knapsack.chpl
@@ -13,6 +13,7 @@ module Problem_Knapsack
   const allowedUpperBounds = ["dantzig", "martello"];
 
   import main_knapsack.findAll as findAll;
+  import main_knapsack.mb as mb;
 
   class Problem_Knapsack : Problem
   {
@@ -129,12 +130,20 @@ module Problem_Knapsack
     {
       var children: list(Node);
 
-      for i in 0..1 {
+      const M = min(mb, this.N - parent.depth);
+      const numChild = 1 << M; // 2^M
+
+      for i in 0..<numChild {
         var child = new Node(parent);
-        child.depth += 1;
-        child.items[parent.depth] = i:uint(32);
-        child.weight += i*this.weights[parent.depth];
-        child.profit += i*this.profits[parent.depth];
+        child.depth += M;
+
+        for j in 0..<M by -1 {
+          const bit = ((i >> j) & 1):uint(32);
+
+          child.items[parent.depth+j] = bit;
+          child.weight += bit*this.weights[parent.depth+j];
+          child.profit += bit*this.profits[parent.depth+j];
+        }
 
         if (child.weight <= this.W) {
           if (child.depth == this.N) { // leaf
@@ -206,12 +215,20 @@ module Problem_Knapsack
     {
       var children: list(Node);
 
-      for i in 0..1 {
+      const M = min(mb, this.N - parent.depth);
+      const numChild = 1 << M; // 2^M
+
+      for i in 0..<numChild {
         var child = new Node(parent);
-        child.depth += 1;
-        child.items[parent.depth] = i:uint(32);
-        child.weight += i*this.weights[parent.depth];
-        child.profit += i*this.profits[parent.depth];
+        child.depth += M;
+
+        for j in 0..<M by -1 {
+          const bit = ((i >> j) & 1):uint(32);
+
+          child.items[parent.depth+j] = bit;
+          child.weight += bit*this.weights[parent.depth+j];
+          child.profit += bit*this.profits[parent.depth+j];
+        }
 
         if (child.weight <= this.W) {
           if (child.depth == this.N) { // leaf
@@ -285,6 +302,7 @@ module Problem_Knapsack
                        else "";
       writeln("  Initial lower bound: ", this.initLB, lbOptMsg);
       writeln("  Upper bound function: ", this.ub_name);
+      if (mb > 1) then writeln("  Multi-variable branching scheme with ", mb, " variables");
       writeln("=================================================");
     }
 
@@ -325,7 +343,8 @@ module Problem_Knapsack
     {
       writeln("\n  Knapsack Benchmark Parameters:\n");
       writeln("   --ub      str       upper bound function (dantzig, martello)");
-      writeln("   --lb      str/int   lower bound initialization ('opt', 'heuristic', or any integer)\n");
+      writeln("   --lb      str/int   lower bound initialization ('opt', 'heuristic', or any integer)");
+      writeln("   --mb      int       multi-variable branching factor\n");
       writeln("   For user-defined instances:\n");
       writeln("    --inst   str       file containing the data\n");
       writeln("   For Pisinger's instances:\n");

--- a/benchmarks/Knapsack/README.md
+++ b/benchmarks/Knapsack/README.md
@@ -31,6 +31,9 @@ where the available options are:
   - `heuristic`: initialize the LB using a greedy fill heuristic up to capacity
   - `{NUM}`: initialize the LB to the given number
 
+- **`--mb`**: multi-variable branching factor
+  - any positive integer (`1` by default)
+
 Specifically for targeting hard Pisinger's instances [3], the following parameters can be used (and `--inst` omitted):
 - **`--n`**: number of items
   - any positive integer (`100` by default)

--- a/main_knapsack.chpl
+++ b/main_knapsack.chpl
@@ -22,6 +22,7 @@ module main_knapsack
   config const inst: string = "";
   config const ub: string   = "dantzig"; // dantzig, martello
   config const lb: string   = "opt"; // opt, inf
+  config const mb: int      = 1; // multi-variable branching factor
 
   config const n: c_int  = 100;
   config const r: c_int  = 10000;

--- a/tests/tests_knapsack_dantzig.sh
+++ b/tests/tests_knapsack_dantzig.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 source ./instances_knapsack.sh
 
+MB="${1:-1}" # default = 1 if not provided
+
+mb_info=""
+[[ "${MB:-1}" != 1 ]] && mb_info=" and mb=$MB"
+
 tests=(
   "KP1"
   "KP2"
@@ -30,10 +35,10 @@ for key in "${tests[@]}"; do
 
   for lb in "${lbs[@]}"; do
     echo "======================================"
-    echo "Testing $key ($args)"
+    echo "Testing $key ($args)$mb_info"
 
     # Run solver
-    if ! output=$(timeout 60s ./main_knapsack.out --mode sequential --ub dantzig --lb $lb $args); then
+    if ! output=$(timeout 60s ./main_knapsack.out --mode sequential --ub dantzig --lb $lb $args --mb $MB); then
       echo "FAIL (timeout or crash)"
       exit 1
     fi
@@ -64,4 +69,4 @@ for key in "${tests[@]}"; do
   done
 done
 
-echo "All Knapsack tests with Dantzig bound passed!"
+echo "All Knapsack tests with Dantzig bound$mb_info passed!"

--- a/tests/tests_knapsack_martello.sh
+++ b/tests/tests_knapsack_martello.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 source ./instances_knapsack.sh
 
+MB="${1:-1}" # default = 1 if not provided
+
+mb_info=""
+[[ "${MB:-1}" != 1 ]] && mb_info=" and mb=$MB"
+
 tests=(
   "KP1"
   "KP2"
@@ -30,10 +35,10 @@ for key in "${tests[@]}"; do
 
   for lb in "${lbs[@]}"; do
     echo "======================================"
-    echo "Testing $key ($args)"
+    echo "Testing $key ($args)$mb_info"
 
     # Run solver
-    if ! output=$(timeout 60s ./main_knapsack.out --mode sequential --ub martello --lb $lb $args); then
+    if ! output=$(timeout 60s ./main_knapsack.out --mode sequential --ub martello --lb $lb $args --mb $MB); then
       echo "FAIL (timeout or crash)"
       exit 1
     fi
@@ -64,4 +69,4 @@ for key in "${tests[@]}"; do
   done
 done
 
-echo "All Knapsack tests with Martello bound passed!"
+echo "All Knapsack tests with Martello bound$mb_info passed!"


### PR DESCRIPTION
Multi-variable branching generalizes the standard branching scheme by assigning multiple decision variables simultaneously when generating child nodes. Instead of selecting a single unassigned variable, the branching operator chooses a set of $N$ unassigned variables { $x_{i_1} , . . . , x_{i_N}$ } and creates one child node for each possible joint assignment of these variables.

The parameter $N$, referred to as the *multi-variable branching factor*, can be configured through the command-line option `--mb`.